### PR TITLE
Remove and Set Filters

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,11 @@
+.nyc_output/
+node_modules/
 src/
 
 .babelrc*
 .eslintrc*
 .groovylintrc*
+.mocharc*
 
+Jenkinsfile
 tsconfig*

--- a/README.md
+++ b/README.md
@@ -468,7 +468,10 @@ The `content` property of a `FilterOperator` is a single object of the form:
 }
 ```
 
-Some filters accept an array of values, number or string, and some only accept a single number. These are differentiated in this library by the types `ArrayFilter` and `ScalarFilter`. You also have access to all the corresponding operation keys in the `FilterKeys`, `ArrayFilterKeys`, and `ScalarFilterKeys` records.
+There are two categories of filters that differ based on the types of values they accept as an argument:
+1. `ArrayFilter` - accept a number, a string, or an array of numbers or strings.
+2. `ScalarFilter` - accept only a single number
+Types are exported that represent these filters, their expected value types `ArrayFilterValue`/`ScalarFilterValue`, as well as types that define the keys available for each filter type and all filters together: `ArrayFilterKeys`, `ScalarFilterKeys` and  `FilterKeys`.
 
 #### CombinationOperators
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ The `content` property of a `FilterOperator` is a single object of the form:
 }
 ```
 
-Some filters accept an array of values, number or string, and some only accept a single number. These are differentiated in this library by the types `ArrayFilterOperator` and `ScalarFilterOperator`. You also have access to all the corresponding operation keys in the `FilterKeys`, `ArrayFilterKeys`, and `ScalarFilterKeys` records.
+Some filters accept an array of values, number or string, and some only accept a single number. These are differentiated in this library by the types `ArrayFilter` and `ScalarFilter`. You also have access to all the corresponding operation keys in the `FilterKeys`, `ArrayFilterKeys`, and `ScalarFilterKeys` records.
 
 #### CombinationOperators
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ SQONBuilder.from(
 );
 ```
 
-This differs from the default function because it will accept any input. The use case for this function is when you have a JS object that could potentially be a valid SQON, you can pass this `uncheckedObject` to `SQONBuilder.from(uncheckedObject)` and validation will be performed before the `SQONBuilder` is returned, if possible.
+This differs from the default function in that it will accept any input (i.e. type `unknown`). The use case for this function is when you have a JS object that could potentially be a valid SQON, you can pass this `uncheckedObject` to `SQONBuilder.from(uncheckedObject)` and validation will be performed before the `SQONBuilder` is returned, if possible.
 
 If the provided string cannot be parsed from JSON a `SyntaxError` will be thrown.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Arranger 3 clarified the SQON property naming, changing `field` to be `fieldName
 			- [FilterOperators](#filteroperators)
 			- [CombinationOperators](#combinationoperators)
 			- [Convenient Type Guards](#convenient-type-guards)
-	- [SQON Reduction](#sqon-reduction)
+		- [SQON Reduction](#sqon-reduction)
+		- [Check Matching Filter](#check-matching-filter)
 
 
 ## How to Use
@@ -362,11 +363,13 @@ if(isCombination(sqon)) {
 }
 ```
 
-## SQON Reduction
+### SQON Reduction
 
-SQONs produced by the SQON builder are run through a reducer function which will remove redundant operators and collect similar filters. For example, if there is an `and` combination wrapping a single filter, the `and` operator can be removed and replaced by the single filter.
+`reduceSQON(sqon: SQON) => SQON`
 
-The reducer function is exported so if you want to reduce a SQON provided by another source:
+The `reduceSQON` function is used internally by the SQON builder to reduce the complexity of a SQON by removing redundant operators and collecting similar filters. For example, if there is an `and` combination wrapping a single filter, the `and` operator can be removed and replaced by the single filter.
+
+The reducer function is exported so you are able to run the reduction algorithm on SQONs independent of the SQONBuilder.
 
 ```ts
 import { reduceSQON } from '@overture-stack/sqon-builder`;
@@ -375,4 +378,18 @@ const sqon: SQON = { op: 'and', 'content': [ { op: 'lt', content: { fieldName: '
 
 const reduced = reduceSQON(sqon);
 // { op: 'lt', content: { fieldName: 'age', value: 100 } }
+```
+
+### Check Matching Filter
+
+`checkMatchingFilter(a: FilterOperator, b: FilterOperator) => boolean`
+
+The `checkMatchingFilter` function will compare two `FilterOperators` and return is they match in all properties. This ensures they have the same filter operation (`op` value), same `fieldName` and matching `value`. Note that for array values, the match is performed independent of order and after removing duplicates - it is a match on the logical content not on the exact array.
+
+```ts
+import { checkMatchingFilter } from '@overture-stack/sqon-builder`;
+const filterA = { op: FilterKeys.In, content: { fieldName: 'name', value: ['Jim', 'Bob', 'May'] } };
+const filterB = {	op: FilterKeys.In, content: { fieldName: 'name', value: ['May', 'Jim', 'Bob'] } };
+
+const matchResult = checkMatchingFilter(filterA, filterB); // true
 ```

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The package default export is the `SQONBuilder`. This is a function that will ge
 
 Example: `const builder: SQONBuilder = SQONBuilder({op: 'in', content: {fieldName: 'name', value: ['Jim']}});`
 
-The `SQONBuilder` function also provides many static functions that can be used to generate a new SQONBuilder without having a SQON to start with.
+The `SQONBuilder` function also provides many static methods that can be used to generate a new SQONBuilder without having a SQON to start with.
 
 Example: `const builder: SQONBuilder = SQONBuilder.in('name', 'Jim');`
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ A SQON is composed from a series of nested `Operators` that take the general str
 ```
 
 There are two types of Operators:
-1. `FilterOperators` - Define a rule used to filter data based on matches to a specific field., for example the `in` filter will find all data that has a field value matching one of the included values in the filter.
+1. `FilterOperators` - Define a rule used to filter data based on matches to a specific field. For example, the `in` filter will find all data that has a field value matching one of the included values in the filter.
 2. `CombinationOperators` - Combine multiple operators with boolean logic. 
 
 #### FilterOperators

--- a/README.md
+++ b/README.md
@@ -408,7 +408,8 @@ const reduced = reduceSQON(sqon);
 The `checkMatchingFilter` function will compare two `FilterOperators` and return is they match in all properties. This ensures they have the same filter operation (`op` value), same `fieldName` and matching `value`. Note that for array values, the match is performed independent of order and after removing duplicates - it is a match on the logical content not on the exact array.
 
 ```ts
-import { checkMatchingFilter } from '@overture-stack/sqon-builder`;
+import { checkMatchingFilter } from '@overture-stack/sqon-builder';
+
 const filterA = { op: FilterKeys.In, content: { fieldName: 'name', value: ['Jim', 'Bob', 'May'] } };
 const filterB = {	op: FilterKeys.In, content: { fieldName: 'name', value: ['May', 'Jim', 'Bob'] } };
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Arranger 3 clarified the SQON property naming, changing `field` to be `fieldName
 	- [API](#api)
 		- [Root](#root)
 		- [Filters](#filters-1)
-			- [SQON.in(fieldName, values)](#sqoninfieldname-values)
-			- [SQON.gt(fieldName, value)](#sqongtfieldname-value)
-			- [SQON.lt(fieldName, value)](#sqonltfieldname-value)
+			- [SQONBuilder.in(fieldName, values)](#sqonbuilderinfieldname-values)
+			- [SQONBuilder.gt(fieldName, value)](#sqonbuildergtfieldname-value)
+			- [SQONBuilder.lt(fieldName, value)](#sqonbuilderltfieldname-value)
 		- [Combinations](#combinations)
-			- [SQON.and(sqon)](#sqonandsqon)
-			- [SQON.or(sqon)](#sqonorsqon)
-			- [SQON.not(sqon)](#sqonnotsqon)
+			- [SQONBuilder.and(sqon)](#sqonbuilderandsqon)
+			- [SQONBuilder.or(sqon)](#sqonbuilderorsqon)
+			- [SQONBuilder.not(sqon)](#sqonbuildernotsqon)
 		- [From](#from)
 	- [Types and SQON Validation](#types-and-sqon-validation)
 		- [SQON Type Composition](#sqon-type-composition)
@@ -211,23 +211,23 @@ This will throw an error if the provided value is not a valid SQON or JSON strin
 
 ### Filters
 
-#### SQON.in(fieldName, values)
+#### SQONBuilder.in(fieldName, values)
 
 Creates a filter requiring the given field to have one of the given values. The value can be a single string or number value, or an array of strings or numbers.
 
-Example: `SQON.in('name',['Jim','Bob'])`
+Example: `SQONBuilder.in('name',['Jim','Bob'])`
 
-#### SQON.gt(fieldName, value)
+#### SQONBuilder.gt(fieldName, value)
 
 Greater Than operator. Create a filter requiring the given field to be greater than the given value
 
-Example: `SQON.gt('age',21)`
+Example: `SQONBuilder.gt('age',21)`
 
-#### SQON.lt(fieldName, value)
+#### SQONBuilder.lt(fieldName, value)
 
 Lesser Than operator. Create a filter requiring the given field to be lesser than the given value
 
-Example: `SQON.lt('count', 100)`
+Example: `SQONBuilder.lt('count', 100)`
 
 ### Combinations
 
@@ -237,23 +237,23 @@ If this is called from an instance, the method will accept one SQON or an array,
 
 If this is called from the class, an array of SQONs is required to be passed.
 
-#### SQON.and(sqon)
+#### SQONBuilder.and(sqon)
 
 All filters in the resulting SQON must be true.
 
-Example: `SQON.and( [someSqon, anotherSqon] )`
+Example: `SQONBuilder.and( [someSqon, anotherSqon] )`
 
-#### SQON.or(sqon)
+#### SQONBuilder.or(sqon)
 
 At least one filter in the resulting SQON must be true.
 
-Example: `SQON.or( [someSqon, anotherSqon] )`
+Example: `SQONBuilder.or( [someSqon, anotherSqon] )`
 
-#### SQON.not(sqon)
+#### SQONBuilder.not(sqon)
 
 None of the filters in the resulting SQON can be true.
 
-Example: `SQON.not( [someSqon] )`
+Example: `SQONBuilder.not( [someSqon] )`
 
 ### From
 
@@ -262,7 +262,7 @@ Build a new SQON from a string or from a JSON object.
 Example with string:
 
 ```ts
-SQON.from(
+SQONBuilder.from(
   '{"op":"and","content":[{"op":"in","content":{"fieldName":"name","value":"Tim"}},{"op":"gt","content":{"fieldName":"age","value":"19"}}]}',
 );
 ```
@@ -341,6 +341,9 @@ To help identify which type of `Operator` the top level of a given `SQON` is, th
 1. `isCombination()` will identify if the input is a `CombinationOperator`
 2. `isFilter()` will identify if the input is a `FilterOperator`
 3. `isArrayFilter()` will further narrow a filter down to see if it can accept an Array of values, or only a single number.
+4. `isScalarFilter()` will further narrow a filter down to see if requires a number as a value.
+5. `isArrayFilterKey()` will identify if the given input is one of the ArrayFilterKeys.
+6. `isScalarFilter()` will identify if the given input is one of the ScalarFilterKeys.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ The `SQONBuilder` function also provides many static functions that can be used 
 
 Example: `const builder: SQONBuilder = SQONBuilder.in('name', 'Jim');`
 
-The `SQONBuilder` object that is returned stores the value of the generated SQON which can be accessed as a string with `.toString()` or as an object with `.toValue()`. From the `SQONBuilder` object you can now combine the stored SQON value with other filters or combination operations.
+The returned `SQONBuilder` object stores the value of the generated SQON which can be accessed as a string with `.toString()` or as an object with `.toValue()`. From the `SQONBuilder` object you can now combine the stored SQON value with other filters or combination operations.
 
 Example: `builder.lt('age','30').gt('score',95);`
 

--- a/src/SQONBuilder.ts
+++ b/src/SQONBuilder.ts
@@ -41,6 +41,12 @@ type SQONBuilder = {
 	 *
 	 * Note: This only looks for filters at the root of the sqon or in the content of the top level combination operator.
 	 * This will not search recursively through the SQON.
+	 * @example
+	 * ```
+	 * const initial = SQONBuilder.in('name', 'Jim').gt('score', 50);
+initial.removeFilter({op: FilterKeys.In, content: {fieldName: 'name', value: ['Jim']}});
+// {op: 'gt', content: {fieldName: 'score', value: 50}}
+	 * ```
 	 * @param filter
 	 * @returns
 	 */
@@ -61,6 +67,23 @@ type SQONBuilder = {
 	 *
 	 * Note: This only looks for filters at the root of the sqon or in the content of the top level combination operator.
 	 * This will not search recursively through the SQON.
+	 *
+	 * @example
+	 * ```
+	 * const builder = SQONBuilder.in('name', ['Jim', 'Bob']).gt('age', 20).lt('age', 50);
+	 *
+	 * // Remove all filters on 'age'
+	 * builder.removeFilter('age');
+	 * // {"op":"in","content":{"fieldName":"name","value":["Jim","Bob"]}}
+	 * ```
+	 * @example
+	 * ```
+	 * const builder = SQONBuilder.in('name', ['Jim', 'Bob', 'May']);
+	 *
+	 * // Remove values in filter
+	 * builder.removeFilter('name', FilterKeys.In, ['Jim', 'Bob', 'Sue']);
+	 * // {"op":"in","content":{"fieldName":"name","value":["May"]}}
+	 * ```
 	 * @param fieldName
 	 * @param op
 	 * @param value
@@ -71,6 +94,14 @@ type SQONBuilder = {
 	/**
 	 * Add a specific filter to the content of the top level operator, or replace a matching filter (same `op` and `fieldName`) with the new value specified.
 	 * If the current SQON is just a filter, then the existing filter and this new filter will be combined with an `and` operator.
+	 *
+	 * @example
+	 * ```
+	 * const builder = SQONBuilder.gt('age', 50).in('name', ['Jim', 'Bob']);
+	 * builder.setFilter('name', FilterKeys.In, ['Jim', 'Sue']);
+	 * // {"op":"and","content":[{"op":"gt","content":{"fieldName":"age","value":50}},{"op":"in","content":{"fieldName":"name","value":["Jim","Sue"]}}]}
+	 * ```
+	 *
 	 * @param fieldName
 	 * @param operator Filter key string
 	 * @param value Filter value of a type that corresponds to the provided operator

--- a/src/SQONBuilder.ts
+++ b/src/SQONBuilder.ts
@@ -35,11 +35,24 @@ type SQONBuilder = {
 	/**
 	 * Find exact matching filter at top level of SQON and remove it from the SQON.
 	 * For filters with an array of values, the order of the array will be ignored during matching.
+	 *
+	 * Note: This only looks for filters at the root of the sqon or in the content of the top level combination operator,
+	 * This will not search recursively through the SQON.
 	 * @param filter
 	 * @returns
 	 */
 	removeExactFilter: (filter: FilterOperator) => SQONBuilder;
 
+	/**
+	 * Find partial matching filter based on optional arguments and remove them from the SQON.
+	 *
+	 * Note: This only looks for filters at the root of the sqon or in the content of the top level combination operator,
+	 * This will not search recursively through the SQON.
+	 * @param fieldName
+	 * @param operator
+	 * @param value
+	 * @returns
+	 */
 	removeFilter: (fieldName: string, operator?: FilterKey, value?: FilterValue) => SQONBuilder;
 
 	/**

--- a/src/SQONBuilder.ts
+++ b/src/SQONBuilder.ts
@@ -198,20 +198,21 @@ const createBuilder = (sqon: SQON): SQONBuilder => {
 		// Filter content to remove all exact matches
 		const filteredContent = _sqon.content.filter((operator) => isCombination(operator) || !isMatchArgs(operator));
 
-		if (valuesToFilter !== undefined) {
-			// we also need to find partial matches for array filters and remove any values that are included in our values array here
-			// map over the filtered content to find any partial matches, then filter values out of the partial match, otherwise return the unmodified operator
-			const outputContent = filteredContent.map((operator) =>
-				isArrayFilter(operator) && isPartialMatchArgs(operator)
-					? filterValuesFromFilter(operator, valuesToFilter)
-					: operator,
-			);
-			const updated: CombinationOperator = { op: _sqon.op, content: outputContent };
-			return createBuilder(updated);
-		} else {
+		if (valuesToFilter === undefined) {
 			const updated: CombinationOperator = { op: _sqon.op, content: filteredContent };
 			return createBuilder(updated);
 		}
+
+		// since we have valuesToFilter, we need to check for partial matches of array filters and remove any values
+		// that are included in our values array here map over the filtered content to find any partial matches, then
+		// filter values out of the partial match, otherwise return the unmodified operator
+		const outputContent = filteredContent.map((operator) =>
+			isArrayFilter(operator) && isPartialMatchArgs(operator)
+				? filterValuesFromFilter(operator, valuesToFilter)
+				: operator,
+		);
+		const updated: CombinationOperator = { op: _sqon.op, content: outputContent };
+		return createBuilder(updated);
 	};
 
 	const setFilter = <Key extends FilterKey>(

--- a/src/SQONBuilder.ts
+++ b/src/SQONBuilder.ts
@@ -8,7 +8,7 @@ import {
 	FilterKeys,
 	FilterOperator,
 	FilterValue,
-	FilterValueMap,
+	FilterTypeMap,
 	GreaterThanFilter,
 	InFilter,
 	LesserThanFilter,
@@ -107,7 +107,11 @@ initial.removeFilter({op: FilterKeys.In, content: {fieldName: 'name', value: ['J
 	 * @param value Filter value of a type that corresponds to the provided operator
 	 * @returns
 	 */
-	setFilter: <Key extends FilterKey>(fieldName: string, op: Key, value: FilterValueMap[Key]) => SQONBuilder;
+	setFilter: <Key extends FilterKey>(
+		fieldName: string,
+		op: Key,
+		value: FilterTypeMap[Key]['content']['value'],
+	) => SQONBuilder;
 
 	/**
 	 * Return a string with the JSON stringified representation of the current SQON
@@ -210,7 +214,11 @@ const createBuilder = (sqon: SQON): SQONBuilder => {
 		}
 	};
 
-	const setFilter = <Key extends FilterKey>(fieldName: string, op: Key, value: FilterValueMap[Key]): SQONBuilder => {
+	const setFilter = <Key extends FilterKey>(
+		fieldName: string,
+		op: Key,
+		value: FilterTypeMap[Key]['content']['value'],
+	): SQONBuilder => {
 		if (isFilter(_sqon)) {
 			// Builder is just one filter, check if it matches our applied filter and replace it, or join them both with an and
 			if (_sqon.op === op && _sqon.content.fieldName === fieldName) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './types/sqon';
 export { default as checkMatchingFilter } from './utils/checkMatchingFilter';
 export { default as reduceSQON } from './utils/reduceSQON';
-import { default as SQONBuilder } from './SQONBuilder';
+export { emptySQON } from './SQONBuilder';
 
+import { default as SQONBuilder } from './SQONBuilder';
 export default SQONBuilder;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types/sqon';
+export { default as checkMatchingFilter } from './utils/checkMatchingFilter';
 export { default as reduceSQON } from './utils/reduceSQON';
 import { default as SQONBuilder } from './SQONBuilder';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from './types/sqon';
-import { default as SQONBuilder } from './SQONBuilder';
 export { default as reduceSQON } from './utils/reduceSQON';
+import { default as SQONBuilder } from './SQONBuilder';
 
 export default SQONBuilder;

--- a/src/types/sqon.ts
+++ b/src/types/sqon.ts
@@ -16,7 +16,7 @@ export const ScalarFilterKeys = {
 export type ScalarFilterKey = Values<typeof ScalarFilterKeys>;
 
 export type FilterKey = ScalarFilterKey | ArrayFilterKey;
-export const FilterKeys = Object.assign(ArrayFilterKeys, ScalarFilterKeys);
+export const FilterKeys = Object.assign({}, ArrayFilterKeys, ScalarFilterKeys);
 
 export const CombinationKeys = {
 	And: 'and',
@@ -25,7 +25,7 @@ export const CombinationKeys = {
 } as const;
 export type CombinationKey = Values<typeof CombinationKeys>;
 
-export const Keys = Object.assign(ArrayFilterKeys, ScalarFilterKeys, CombinationKeys);
+export const Keys = Object.assign({}, ArrayFilterKeys, ScalarFilterKeys, CombinationKeys);
 
 /* ****************** *
  * Filters            *
@@ -51,6 +51,12 @@ export const ScalarFilterValue = zod.number();
 
 export type FilterValue = zod.infer<typeof FilterValue>;
 export const FilterValue = zod.union([ArrayFilterValue, ScalarFilterValue]);
+
+export type FilterValueMap = {
+	[ArrayFilterKeys.In]: ArrayFilterValue;
+	[ScalarFilterKeys.GreaterThan]: ScalarFilterValue;
+	[ScalarFilterKeys.LesserThan]: ScalarFilterValue;
+};
 
 /* ===== Specific Filters ==== */
 
@@ -119,12 +125,20 @@ export const SQON = Operator;
 export type SQON = Clean<Operator>;
 
 /* ===== Convenient Type Guards ===== */
-export const isCombination = (operator: Operator): operator is CombinationOperator => {
-	return CombinationOperator.safeParse(operator).success;
-};
-export const isFilter = (operator: Operator): operator is FilterOperator => {
-	return FilterOperator.safeParse(operator).success;
-};
-export const isArrayFilter = (operator: Operator): operator is ArrayFilter => {
-	return ArrayFilter.safeParse(operator).success;
-};
+export const isCombination = (operator: Operator): operator is CombinationOperator =>
+	CombinationOperator.safeParse(operator).success;
+
+export const isFilter = (operator: Operator): operator is FilterOperator => FilterOperator.safeParse(operator).success;
+
+export const isArrayFilter = (operator: Operator): operator is ArrayFilter => ArrayFilter.safeParse(operator).success;
+
+export const isScalarFilter = (operator: Operator): operator is ScalarFilter =>
+	ScalarFilter.safeParse(operator).success;
+
+const arrayFilterKeys: string[] = Object.values(ArrayFilterKeys);
+export const isArrayFilterKey = (input: unknown): input is ArrayFilterKey =>
+	typeof input === 'string' && arrayFilterKeys.includes(input);
+
+const scalarFilterKeys: string[] = Object.values(ScalarFilterKeys);
+export const isScalarFilterKey = (input: unknown): input is ScalarFilterKey =>
+	typeof input === 'string' && scalarFilterKeys.includes(input);

--- a/src/types/sqon.ts
+++ b/src/types/sqon.ts
@@ -142,3 +142,8 @@ export const isArrayFilterKey = (input: unknown): input is ArrayFilterKey =>
 const scalarFilterKeys: string[] = Object.values(ScalarFilterKeys);
 export const isScalarFilterKey = (input: unknown): input is ScalarFilterKey =>
 	typeof input === 'string' && scalarFilterKeys.includes(input);
+
+export const isArrayFilterValue = (value: unknown): value is ArrayFilterValue =>
+	ArrayFilterValue.safeParse(value).success;
+export const isScalarFilterValue = (value: unknown): value is ScalarFilterValue =>
+	ScalarFilterValue.safeParse(value).success;

--- a/src/types/sqon.ts
+++ b/src/types/sqon.ts
@@ -52,10 +52,10 @@ export const ScalarFilterValue = zod.number();
 export type FilterValue = zod.infer<typeof FilterValue>;
 export const FilterValue = zod.union([ArrayFilterValue, ScalarFilterValue]);
 
-export type FilterValueMap = {
-	[ArrayFilterKeys.In]: ArrayFilterValue;
-	[ScalarFilterKeys.GreaterThan]: ScalarFilterValue;
-	[ScalarFilterKeys.LesserThan]: ScalarFilterValue;
+export type FilterTypeMap = {
+	[ArrayFilterKeys.In]: InFilter;
+	[ScalarFilterKeys.GreaterThan]: GreaterThanFilter;
+	[ScalarFilterKeys.LesserThan]: LesserThanFilter;
 };
 
 /* ===== Specific Filters ==== */

--- a/src/utils/checkMatchingFilter.ts
+++ b/src/utils/checkMatchingFilter.ts
@@ -14,8 +14,10 @@ const checkMatchingFilter = (a: FilterOperator, b: FilterOperator): boolean => {
 		return false;
 	}
 
+	// Clone values into arrays and sort them so we can compare item by item.
 	const valuesA = [...asArray(a.content.value)].sort();
 	const valuesB = [...asArray(b.content.value)].sort();
+	// This check requires that each array is the same length so we can compare them item by item
 	return valuesA.length === valuesB.length && valuesA.every((value, index) => value === valuesB[index]);
 };
 

--- a/src/utils/checkMatchingFilter.ts
+++ b/src/utils/checkMatchingFilter.ts
@@ -1,5 +1,23 @@
 import { FilterOperator, isArrayFilter } from '../types/sqon';
 import asArray from './asArray';
+import filterDuplicates from './filterDuplicates';
+
+/**
+ * Compare two arrays ensuring they have the same elements. This removes duplicates and compares them
+ * item by item in sorted order.
+ *
+ * Note this will work well with primatives. For arrays of objects it will be matching by reference and not by value.
+ *
+ * @param a
+ * @param b
+ * @returns
+ */
+export const checkMatchingArrays = <T>(a: T[], b: T[]): boolean => {
+	const valuesA = [...a].filter(filterDuplicates).sort();
+	const valuesB = [...b].filter(filterDuplicates).sort();
+	// This check requires that each array is the same length so we can compare them item by item
+	return valuesA.length === valuesB.length && valuesA.every((value, index) => value === valuesB[index]);
+};
 
 /**
  * Check if two filters are equivalent.
@@ -15,10 +33,7 @@ const checkMatchingFilter = (a: FilterOperator, b: FilterOperator): boolean => {
 	}
 
 	// Clone values into arrays and sort them so we can compare item by item.
-	const valuesA = [...asArray(a.content.value)].sort();
-	const valuesB = [...asArray(b.content.value)].sort();
-	// This check requires that each array is the same length so we can compare them item by item
-	return valuesA.length === valuesB.length && valuesA.every((value, index) => value === valuesB[index]);
+	return checkMatchingArrays(asArray(a.content.value), asArray(b.content.value));
 };
 
 export default checkMatchingFilter;

--- a/src/utils/checkMatchingFilter.ts
+++ b/src/utils/checkMatchingFilter.ts
@@ -1,0 +1,22 @@
+import { FilterOperator, isArrayFilter } from '../types/sqon';
+import asArray from './asArray';
+
+/**
+ * Check if two filters are equivalent.
+ * In addition to checking if op and content.fieldName are matching strings, this
+ * will compare values as sorted arrays so that any mixed orders do not prevent matching.
+ * @param a
+ * @param b
+ * @returns
+ */
+const checkMatchingFilter = (a: FilterOperator, b: FilterOperator): boolean => {
+	if (a.op !== b.op || a.content.fieldName !== b.content.fieldName) {
+		return false;
+	}
+
+	const valuesA = [...asArray(a.content.value)].sort();
+	const valuesB = [...asArray(b.content.value)].sort();
+	return valuesA.length === valuesB.length && valuesA.every((value, index) => value === valuesB[index]);
+};
+
+export default checkMatchingFilter;

--- a/src/utils/checkMatchingFilter.ts
+++ b/src/utils/checkMatchingFilter.ts
@@ -28,12 +28,12 @@ export const checkMatchingArrays = <T>(a: T[], b: T[]): boolean => {
  * @returns
  */
 const checkMatchingFilter = (a: FilterOperator, b: FilterOperator): boolean => {
-	if (a.op !== b.op || a.content.fieldName !== b.content.fieldName) {
-		return false;
+	if (a.op === b.op && a.content.fieldName === b.content.fieldName) {
+		// Clone values into arrays and sort them so we can compare item by item.
+		return checkMatchingArrays(asArray(a.content.value), asArray(b.content.value));
 	}
 
-	// Clone values into arrays and sort them so we can compare item by item.
-	return checkMatchingArrays(asArray(a.content.value), asArray(b.content.value));
+	return false;
 };
 
 export default checkMatchingFilter;

--- a/src/utils/cloneDeepValues.ts
+++ b/src/utils/cloneDeepValues.ts
@@ -11,9 +11,9 @@ type StripFunctions<T extends { [key: string]: any }> = T extends infer U
  * @param source
  * @returns
  */
-const cloneDeepPojo = <T extends { [key: string]: any }>(source: T): StripFunctions<T> => {
+const cloneDeepValues = <T extends { [key: string]: any }>(source: T): StripFunctions<T> => {
 	return Array.isArray(source)
-		? source.map((item) => cloneDeepPojo(item))
+		? source.map((item) => cloneDeepValues(item))
 		: source && typeof source === 'object'
 		? Object.getOwnPropertyNames(source).reduce((o, prop) => {
 				if (typeof source[prop] === 'function') {
@@ -21,10 +21,10 @@ const cloneDeepPojo = <T extends { [key: string]: any }>(source: T): StripFuncti
 					return o;
 				}
 				Object.defineProperty(o, prop, Object.getOwnPropertyDescriptor(source, prop)!);
-				o[prop] = cloneDeepPojo(source[prop]);
+				o[prop] = cloneDeepValues(source[prop]);
 				return o;
 		  }, Object.create(Object.getPrototypeOf(source)))
 		: source;
 };
 
-export default cloneDeepPojo;
+export default cloneDeepValues;

--- a/src/utils/createFilter.ts
+++ b/src/utils/createFilter.ts
@@ -14,9 +14,6 @@ export const createFilter = <Key extends FilterKey>(
 	op: Key,
 	value: FilterTypeMap[Key]['content']['value'],
 ): FilterOperator => {
-	if (op === 'gt') {
-		const x = value;
-	}
 	if (isArrayFilterKey(op)) {
 		return { op, content: { fieldName, value: asArray(value) } };
 	} else if (isScalarFilterKey(op) && isScalarFilterValue(value)) {

--- a/src/utils/createFilter.ts
+++ b/src/utils/createFilter.ts
@@ -1,9 +1,7 @@
 import {
-	ArrayFilterValue,
 	FilterKey,
 	FilterOperator,
-	FilterValueMap,
-	ScalarFilterValue,
+	FilterTypeMap,
 	isArrayFilterKey,
 	isArrayFilterValue,
 	isScalarFilterKey,
@@ -14,9 +12,12 @@ import asArray from './asArray';
 export const createFilter = <Key extends FilterKey>(
 	fieldName: string,
 	op: Key,
-	value: FilterValueMap[Key],
+	value: FilterTypeMap[Key]['content']['value'],
 ): FilterOperator => {
-	if (isArrayFilterKey(op) && isArrayFilterValue(value)) {
+	if (op === 'gt') {
+		const x = value;
+	}
+	if (isArrayFilterKey(op)) {
 		return { op, content: { fieldName, value: asArray(value) } };
 	} else if (isScalarFilterKey(op) && isScalarFilterValue(value)) {
 		return { op, content: { fieldName, value } };
@@ -26,3 +27,5 @@ export const createFilter = <Key extends FilterKey>(
 		throw new TypeError(`Cannot assign the value "${value}" to a filter of type "${op}".`);
 	}
 };
+
+createFilter('a', 'in', ['1']);

--- a/src/utils/createFilter.ts
+++ b/src/utils/createFilter.ts
@@ -1,10 +1,13 @@
 import {
+	ArrayFilterValue,
 	FilterKey,
 	FilterOperator,
 	FilterValueMap,
 	ScalarFilterValue,
 	isArrayFilterKey,
+	isArrayFilterValue,
 	isScalarFilterKey,
+	isScalarFilterValue,
 } from '../types/sqon';
 import asArray from './asArray';
 
@@ -13,11 +16,13 @@ export const createFilter = <Key extends FilterKey>(
 	op: Key,
 	value: FilterValueMap[Key],
 ): FilterOperator => {
-	if (isArrayFilterKey(op)) {
+	if (isArrayFilterKey(op) && isArrayFilterValue(value)) {
 		return { op, content: { fieldName, value: asArray(value) } };
+	} else if (isScalarFilterKey(op) && isScalarFilterValue(value)) {
+		return { op, content: { fieldName, value } };
 	} else {
-		// TS will ensure x is a ScalarFilterValue but the type inference isnt keeping up
-		// TODO: there must be a way to get the type inference to work here
-		return { op, content: { fieldName, value: value as ScalarFilterValue } };
+		// This code should not be reached if the typescript checks are adhered to, the value argument should always be appropriate for the op
+		// However, should the checks fail and an incorrect value is provided for the given op this will throw an error.
+		throw new TypeError(`Cannot assign the value "${value}" to a filter of type "${op}".`);
 	}
 };

--- a/src/utils/createFilter.ts
+++ b/src/utils/createFilter.ts
@@ -1,0 +1,23 @@
+import {
+	FilterKey,
+	FilterOperator,
+	FilterValueMap,
+	ScalarFilterValue,
+	isArrayFilterKey,
+	isScalarFilterKey,
+} from '../types/sqon';
+import asArray from './asArray';
+
+export const createFilter = <Key extends FilterKey>(
+	fieldName: string,
+	op: Key,
+	value: FilterValueMap[Key],
+): FilterOperator => {
+	if (isArrayFilterKey(op)) {
+		return { op, content: { fieldName, value: asArray(value) } };
+	} else {
+		// TS will ensure x is a ScalarFilterValue but the type inference isnt keeping up
+		// TODO: there must be a way to get the type inference to work here
+		return { op, content: { fieldName, value: value as ScalarFilterValue } };
+	}
+};

--- a/src/utils/reduceSQON.ts
+++ b/src/utils/reduceSQON.ts
@@ -1,7 +1,7 @@
 import {
-	ArrayFilterKeys,
 	CombinationKeys,
 	CombinationOperator,
+	FilterKeys,
 	FilterOperator,
 	SQON,
 	ScalarFilterKeys,
@@ -10,7 +10,6 @@ import {
 } from '../types/sqon';
 import asArray from './asArray';
 import filterDuplicates from './filterDuplicates';
-
 const deduplicateValues = (filter: FilterOperator): FilterOperator => {
 	if (isArrayFilter(filter)) {
 		return {
@@ -53,7 +52,7 @@ const reduceSQON = (sqon: SQON): SQON => {
 					 * - 5. multiple IN on the same 'or'/'and'/'not' combo can be combined into a list
 					 */
 					// In this if/else chain we check both the match and the innersqon match. we know this is true thanks to the .find that found the match, but this is needed for the type checker
-					if (match.op === ScalarFilterKeys.GreaterThan && innerSqon.op === ScalarFilterKeys.GreaterThan) {
+					if (match.op === FilterKeys.GreaterThan && innerSqon.op === FilterKeys.GreaterThan) {
 						if (output.op === CombinationKeys.And || output.op === CombinationKeys.Not) {
 							// 1. multiple GT on the same 'and'/'not' combo can be a single with the greater value
 							match.content.value = Math.max(match.content.value, innerSqon.content.value);
@@ -63,7 +62,7 @@ const reduceSQON = (sqon: SQON): SQON => {
 						}
 					}
 
-					if (match.op === ScalarFilterKeys.LesserThan && innerSqon.op === ScalarFilterKeys.LesserThan) {
+					if (match.op === FilterKeys.LesserThan && innerSqon.op === FilterKeys.LesserThan) {
 						if (output.op === CombinationKeys.And || output.op === CombinationKeys.Not) {
 							// 3. multiple LT on the same 'and'/'not combo can be the lesser value
 							match.content.value = Math.min(match.content.value, innerSqon.content.value);
@@ -73,7 +72,7 @@ const reduceSQON = (sqon: SQON): SQON => {
 						}
 					}
 
-					if (match.op === ArrayFilterKeys.In && innerSqon.op === ArrayFilterKeys.In) {
+					if (match.op === FilterKeys.In && innerSqon.op === FilterKeys.In) {
 						// 5. multiple IN on the same 'or'/'and'/'not' combo can be combined into a list
 						match.content.value = [...asArray(match.content.value), ...asArray(innerSqon.content.value)];
 					}

--- a/src/utils/reduceSQON.ts
+++ b/src/utils/reduceSQON.ts
@@ -9,13 +9,12 @@ import {
 	isFilter,
 } from '../types/sqon';
 import asArray from './asArray';
+import { createFilter } from './createFilter';
 import filterDuplicates from './filterDuplicates';
 const deduplicateValues = (filter: FilterOperator): FilterOperator => {
 	if (isArrayFilter(filter)) {
-		return {
-			op: filter.op,
-			content: { fieldName: filter.content.fieldName, value: asArray(filter.content.value).filter(filterDuplicates) },
-		};
+		const value = asArray(filter.content.value).filter(filterDuplicates);
+		return createFilter(filter.content.fieldName, filter.op, value);
 	}
 	return filter;
 };

--- a/test/SQONBuilder.spec.ts
+++ b/test/SQONBuilder.spec.ts
@@ -1,20 +1,27 @@
 import { expect } from 'chai';
 import { ZodError } from 'zod';
-import SQONBuilder, { ArrayFilterKeys, CombinationKeys, SQON, ScalarFilterKeys } from '../src';
+import SQONBuilder, {
+	ArrayFilterKeys,
+	CombinationKeys,
+	FilterKeys,
+	FilterOperator,
+	SQON,
+	ScalarFilterKeys,
+} from '../src';
 import reduceSQON from '../src/utils/reduceSQON';
 
 describe('SQONBuilder', () => {
 	describe('Root', () => {
 		it('accepts a sqon', () => {
 			const expectedSqon: SQON = {
-				op: ArrayFilterKeys.In,
+				op: FilterKeys.In,
 				content: {
 					fieldName: 'score',
 					value: [100],
 				},
 			};
 			const builder = SQONBuilder({
-				op: ArrayFilterKeys.In,
+				op: FilterKeys.In,
 				content: {
 					fieldName: 'score',
 					value: [100],
@@ -30,14 +37,14 @@ describe('SQONBuilder', () => {
 						op: CombinationKeys.And,
 						content: [
 							{
-								op: ArrayFilterKeys.In,
+								op: FilterKeys.In,
 								content: {
 									fieldName: 'name',
 									value: 'Jim',
 								},
 							},
 							{
-								op: ArrayFilterKeys.In,
+								op: FilterKeys.In,
 								content: {
 									fieldName: 'name',
 									value: ['Bob', 'Greg'],
@@ -62,7 +69,7 @@ describe('SQONBuilder', () => {
 		it('accepts a valid JSON string', () => {
 			const input = `{"op":"in","content":{"fieldName":"name","value":["Jim"]}}`;
 			const expectedSqon: SQON = {
-				op: ArrayFilterKeys.In,
+				op: FilterKeys.In,
 				content: {
 					fieldName: 'name',
 					value: ['Jim'],
@@ -86,7 +93,7 @@ describe('SQONBuilder', () => {
 		describe('in', () => {
 			it('single number', () => {
 				const expectedSqon: SQON = {
-					op: ArrayFilterKeys.In,
+					op: FilterKeys.In,
 					content: {
 						fieldName: 'score',
 						value: [100],
@@ -97,7 +104,7 @@ describe('SQONBuilder', () => {
 			});
 			it('single string', () => {
 				const expectedSqon: SQON = {
-					op: ArrayFilterKeys.In,
+					op: FilterKeys.In,
 					content: {
 						fieldName: 'name',
 						value: ['Jim'],
@@ -108,7 +115,7 @@ describe('SQONBuilder', () => {
 			});
 			it('array number', () => {
 				const expectedSqon: SQON = {
-					op: ArrayFilterKeys.In,
+					op: FilterKeys.In,
 					content: {
 						fieldName: 'score',
 						value: [95, 96, 97, 98, 99, 100],
@@ -119,7 +126,7 @@ describe('SQONBuilder', () => {
 			});
 			it('array string', () => {
 				const expectedSqon: SQON = {
-					op: ArrayFilterKeys.In,
+					op: FilterKeys.In,
 					content: {
 						fieldName: 'name',
 						value: ['Jim', 'Bob'],
@@ -130,7 +137,7 @@ describe('SQONBuilder', () => {
 			});
 			it('removes duplicates', () => {
 				const expectedSqon: SQON = {
-					op: ArrayFilterKeys.In,
+					op: FilterKeys.In,
 					content: {
 						fieldName: 'name',
 						value: ['Jim', 'Bob'],
@@ -143,7 +150,7 @@ describe('SQONBuilder', () => {
 		describe('gt', () => {
 			it('generates filter', () => {
 				const expectedSqon: SQON = {
-					op: ScalarFilterKeys.GreaterThan,
+					op: FilterKeys.GreaterThan,
 					content: {
 						fieldName: 'score',
 						value: 95,
@@ -156,7 +163,7 @@ describe('SQONBuilder', () => {
 		describe('lt', () => {
 			it('generates filter', () => {
 				const expectedSqon: SQON = {
-					op: ScalarFilterKeys.LesserThan,
+					op: FilterKeys.LesserThan,
 					content: {
 						fieldName: 'score',
 						value: 50,
@@ -172,14 +179,14 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.And,
 					content: [
 						{
-							op: ScalarFilterKeys.GreaterThan,
+							op: FilterKeys.GreaterThan,
 							content: {
 								fieldName: 'score',
 								value: 95,
 							},
 						},
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'name',
 								value: ['Jim', 'Bob'],
@@ -192,7 +199,7 @@ describe('SQONBuilder', () => {
 			});
 			it('reduces a single filter', () => {
 				const expectedSqon: SQON = {
-					op: ScalarFilterKeys.GreaterThan,
+					op: FilterKeys.GreaterThan,
 					content: {
 						fieldName: 'score',
 						value: 95,
@@ -203,7 +210,7 @@ describe('SQONBuilder', () => {
 			});
 			it('reduces a single combination operator', () => {
 				const expectedSqon: SQON = {
-					op: ScalarFilterKeys.GreaterThan,
+					op: FilterKeys.GreaterThan,
 					content: {
 						fieldName: 'score',
 						value: 95,
@@ -213,7 +220,7 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.Or,
 					content: [
 						{
-							op: ScalarFilterKeys.GreaterThan,
+							op: FilterKeys.GreaterThan,
 							content: { fieldName: 'score', value: 95 },
 						},
 					],
@@ -226,14 +233,14 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.And,
 					content: [
 						{
-							op: ScalarFilterKeys.GreaterThan,
+							op: FilterKeys.GreaterThan,
 							content: {
 								fieldName: 'score',
 								value: 95,
 							},
 						},
 						{
-							op: ScalarFilterKeys.LesserThan,
+							op: FilterKeys.LesserThan,
 							content: {
 								fieldName: 'age',
 								value: 40,
@@ -254,14 +261,14 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.Or,
 					content: [
 						{
-							op: ScalarFilterKeys.GreaterThan,
+							op: FilterKeys.GreaterThan,
 							content: {
 								fieldName: 'score',
 								value: 95,
 							},
 						},
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'name',
 								value: ['Jim', 'Bob'],
@@ -274,7 +281,7 @@ describe('SQONBuilder', () => {
 			});
 			it('reduces a single filter', () => {
 				const expectedSqon: SQON = {
-					op: ScalarFilterKeys.GreaterThan,
+					op: FilterKeys.GreaterThan,
 					content: {
 						fieldName: 'score',
 						value: 95,
@@ -288,14 +295,14 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.Or,
 					content: [
 						{
-							op: ScalarFilterKeys.GreaterThan,
+							op: FilterKeys.GreaterThan,
 							content: {
 								fieldName: 'score',
 								value: 95,
 							},
 						},
 						{
-							op: ScalarFilterKeys.LesserThan,
+							op: FilterKeys.LesserThan,
 							content: {
 								fieldName: 'age',
 								value: 40,
@@ -311,7 +318,7 @@ describe('SQONBuilder', () => {
 			});
 			it('or(lt(a), lt(a)) reduces to lt() with max', () => {
 				const expectedSqon: SQON = {
-					op: ScalarFilterKeys.LesserThan,
+					op: FilterKeys.LesserThan,
 					content: {
 						fieldName: 'score',
 						value: 55,
@@ -322,7 +329,7 @@ describe('SQONBuilder', () => {
 			});
 			it('or(gt(a), gt(a)) reduces to gt() with min', () => {
 				const expectedSqon: SQON = {
-					op: ScalarFilterKeys.GreaterThan,
+					op: FilterKeys.GreaterThan,
 					content: {
 						fieldName: 'score',
 						value: 85,
@@ -338,14 +345,14 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.Not,
 					content: [
 						{
-							op: ScalarFilterKeys.GreaterThan,
+							op: FilterKeys.GreaterThan,
 							content: {
 								fieldName: 'score',
 								value: 95,
 							},
 						},
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'name',
 								value: ['Jim', 'Bob'],
@@ -361,7 +368,7 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.Not,
 					content: [
 						{
-							op: ScalarFilterKeys.GreaterThan,
+							op: FilterKeys.GreaterThan,
 							content: {
 								fieldName: 'score',
 								value: 95,
@@ -377,14 +384,14 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.Not,
 					content: [
 						{
-							op: ScalarFilterKeys.GreaterThan,
+							op: FilterKeys.GreaterThan,
 							content: {
 								fieldName: 'score',
 								value: 95,
 							},
 						},
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'name',
 								value: ['Jim', 'Bob'],
@@ -409,7 +416,7 @@ describe('SQONBuilder', () => {
 			});
 			it('creates builder from valid sqon', () => {
 				const input: SQON = {
-					op: ArrayFilterKeys.In,
+					op: FilterKeys.In,
 					content: {
 						fieldName: 'score',
 						value: [100],
@@ -421,7 +428,7 @@ describe('SQONBuilder', () => {
 			it('creates builder from valid string', () => {
 				const input = `{"op":"in","content":{"fieldName":"name","value":["Jim"]}}`;
 				const expectedSqon: SQON = {
-					op: ArrayFilterKeys.In,
+					op: FilterKeys.In,
 					content: {
 						fieldName: 'name',
 						value: ['Jim'],
@@ -433,7 +440,7 @@ describe('SQONBuilder', () => {
 			it('throws ZodError for invalid object', () => {
 				// invalid op type for value
 				const invalid = {
-					op: ScalarFilterKeys.GreaterThan,
+					op: FilterKeys.GreaterThan,
 					content: {
 						fieldName: 'name',
 						value: ['Jim'],
@@ -464,7 +471,7 @@ describe('SQONBuilder', () => {
 		describe('toValue', () => {
 			it('returns object matching sqon', () => {
 				const expectedSqon: SQON = {
-					op: ArrayFilterKeys.In,
+					op: FilterKeys.In,
 					content: {
 						fieldName: 'name',
 						value: ['Jim'],
@@ -478,20 +485,21 @@ describe('SQONBuilder', () => {
 				expect(Object.values(output).some((value) => typeof value === 'function')).false;
 			});
 		});
+
 		describe('in', () => {
 			it('gt().in() combines with and', () => {
 				const expectedSqon: SQON = {
 					op: CombinationKeys.And,
 					content: [
 						{
-							op: ScalarFilterKeys.GreaterThan,
+							op: FilterKeys.GreaterThan,
 							content: {
 								fieldName: 'score',
 								value: 95,
 							},
 						},
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'name',
 								value: ['Jim', 'Bob'],
@@ -504,7 +512,7 @@ describe('SQONBuilder', () => {
 			});
 			it('in(a).in(a) on same name collects into single filter', () => {
 				const expectedSqon: SQON = {
-					op: ArrayFilterKeys.In,
+					op: FilterKeys.In,
 					content: {
 						fieldName: 'name',
 						value: ['Jim', 'Bob', 'Greg'],
@@ -518,14 +526,14 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.And,
 					content: [
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'class',
 								value: ['Bio', 'Math'],
 							},
 						},
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'name',
 								value: ['Jim', 'Bob'],
@@ -541,14 +549,14 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.And,
 					content: [
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'name',
 								value: ['Jim', 'Bob'],
 							},
 						},
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'class',
 								value: ['Bio'],
@@ -566,14 +574,14 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.And,
 					content: [
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'name',
 								value: ['Jim', 'Bob'],
 							},
 						},
 						{
-							op: ScalarFilterKeys.GreaterThan,
+							op: FilterKeys.GreaterThan,
 							content: {
 								fieldName: 'score',
 								value: 95,
@@ -586,7 +594,7 @@ describe('SQONBuilder', () => {
 			});
 			it('gt(a).gt(a) with same name collects into single filter with max value', () => {
 				const expectedSqon: SQON = {
-					op: ScalarFilterKeys.GreaterThan,
+					op: FilterKeys.GreaterThan,
 					content: {
 						fieldName: 'score',
 						value: 97,
@@ -600,14 +608,14 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.And,
 					content: [
 						{
-							op: ScalarFilterKeys.GreaterThan,
+							op: FilterKeys.GreaterThan,
 							content: {
 								fieldName: 'score',
 								value: 90,
 							},
 						},
 						{
-							op: ScalarFilterKeys.GreaterThan,
+							op: FilterKeys.GreaterThan,
 							content: {
 								fieldName: 'age',
 								value: 20,
@@ -625,14 +633,14 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.And,
 					content: [
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'name',
 								value: ['Jim', 'Bob'],
 							},
 						},
 						{
-							op: ScalarFilterKeys.LesserThan,
+							op: FilterKeys.LesserThan,
 							content: {
 								fieldName: 'score',
 								value: 50,
@@ -645,7 +653,7 @@ describe('SQONBuilder', () => {
 			});
 			it('lt(a).lt(a) with same name collects into single filter with min value', () => {
 				const expectedSqon: SQON = {
-					op: ScalarFilterKeys.LesserThan,
+					op: FilterKeys.LesserThan,
 					content: {
 						fieldName: 'score',
 						value: 45,
@@ -659,14 +667,14 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.And,
 					content: [
 						{
-							op: ScalarFilterKeys.LesserThan,
+							op: FilterKeys.LesserThan,
 							content: {
 								fieldName: 'score',
 								value: 51,
 							},
 						},
 						{
-							op: ScalarFilterKeys.LesserThan,
+							op: FilterKeys.LesserThan,
 							content: {
 								fieldName: 'age',
 								value: 40,
@@ -684,14 +692,14 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.And,
 					content: [
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'name',
 								value: ['Jim', 'Bob'],
 							},
 						},
 						{
-							op: ScalarFilterKeys.LesserThan,
+							op: FilterKeys.LesserThan,
 							content: {
 								fieldName: 'score',
 								value: 50,
@@ -710,14 +718,14 @@ describe('SQONBuilder', () => {
 							op: CombinationKeys.Or,
 							content: [
 								{
-									op: ScalarFilterKeys.GreaterThan,
+									op: FilterKeys.GreaterThan,
 									content: {
 										fieldName: 'score',
 										value: 95,
 									},
 								},
 								{
-									op: ArrayFilterKeys.In,
+									op: FilterKeys.In,
 									content: {
 										fieldName: 'name',
 										value: ['Jim', 'Bob'],
@@ -726,7 +734,7 @@ describe('SQONBuilder', () => {
 							],
 						},
 						{
-							op: ScalarFilterKeys.LesserThan,
+							op: FilterKeys.LesserThan,
 							content: {
 								fieldName: 'age',
 								value: 22,
@@ -746,14 +754,14 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.Or,
 					content: [
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'name',
 								value: ['Jim', 'Bob'],
 							},
 						},
 						{
-							op: ScalarFilterKeys.LesserThan,
+							op: FilterKeys.LesserThan,
 							content: {
 								fieldName: 'score',
 								value: 50,
@@ -769,21 +777,21 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.Or,
 					content: [
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'name',
 								value: ['Jim', 'Bob'],
 							},
 						},
 						{
-							op: ScalarFilterKeys.LesserThan,
+							op: FilterKeys.LesserThan,
 							content: {
 								fieldName: 'score',
 								value: 50,
 							},
 						},
 						{
-							op: ScalarFilterKeys.GreaterThan,
+							op: FilterKeys.GreaterThan,
 							content: {
 								fieldName: 'age',
 								value: 25,
@@ -803,7 +811,7 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.And,
 					content: [
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'name',
 								value: ['Jim', 'Bob'],
@@ -813,7 +821,7 @@ describe('SQONBuilder', () => {
 							op: CombinationKeys.Not,
 							content: [
 								{
-									op: ScalarFilterKeys.LesserThan,
+									op: FilterKeys.LesserThan,
 									content: {
 										fieldName: 'score',
 										value: 50,
@@ -838,7 +846,7 @@ describe('SQONBuilder', () => {
 					op: CombinationKeys.And,
 					content: [
 						{
-							op: ArrayFilterKeys.In,
+							op: FilterKeys.In,
 							content: {
 								fieldName: 'name',
 								value: ['Jim', 'Bob'],
@@ -848,7 +856,7 @@ describe('SQONBuilder', () => {
 							op: CombinationKeys.Not,
 							content: [
 								{
-									op: ScalarFilterKeys.LesserThan,
+									op: FilterKeys.LesserThan,
 									content: {
 										fieldName: 'score',
 										value: 50,
@@ -860,7 +868,7 @@ describe('SQONBuilder', () => {
 							op: CombinationKeys.Not,
 							content: [
 								{
-									op: ScalarFilterKeys.GreaterThan,
+									op: FilterKeys.GreaterThan,
 									content: {
 										fieldName: 'age',
 										value: 25,
@@ -874,6 +882,56 @@ describe('SQONBuilder', () => {
 					.not(SQONBuilder.lt('score', 50))
 					.not(SQONBuilder.gt('age', 25));
 				expect(output).deep.contain(expectedSqon);
+			});
+		});
+		describe('removeExactFilter', () => {
+			it('removes matching filter', () => {
+				const filter: FilterOperator = { op: FilterKeys.In, content: { fieldName: 'name', value: ['Jim'] } };
+				const base = SQONBuilder.gt('score', 90).in('name', 'Jim');
+				const output = base.removeExactFilter(filter);
+
+				const expected = SQONBuilder.gt('score', 90);
+
+				expect(output).deep.contain(expected.toValue());
+			});
+			it('removes matching filter with array values independent of order', () => {
+				const filter: FilterOperator = {
+					op: FilterKeys.In,
+					content: { fieldName: 'name', value: ['Jim', 'Bob', 'May', 'Sue'] },
+				};
+				const base = SQONBuilder.gt('score', 90).in('name', ['May', 'Sue', 'Bob', 'Jim']);
+				const output = base.removeExactFilter(filter);
+
+				const expected = SQONBuilder.gt('score', 90);
+
+				expect(output).deep.contain(expected.toValue());
+			});
+			it('transforms filter to empty `and` operator', () => {
+				const filter: FilterOperator = { op: FilterKeys.In, content: { fieldName: 'name', value: ['Jim'] } };
+				const base = SQONBuilder.in('name', 'Jim');
+				const output = base.removeExactFilter(filter);
+
+				const expected = SQONBuilder.and([]);
+
+				expect(output).deep.contain(expected.toValue());
+			});
+			it('makes no change when filter is not found', () => {
+				const filter: FilterOperator = { op: FilterKeys.In, content: { fieldName: 'name', value: ['Jim'] } };
+				const base = SQONBuilder.gt('score', 90).lt('age', 50);
+				const output = base.removeExactFilter(filter);
+
+				const expected = base;
+
+				expect(output).deep.contain(expected.toValue());
+			});
+			it('makes no change to non matching filter', () => {
+				const filter: FilterOperator = { op: FilterKeys.In, content: { fieldName: 'name', value: ['Jim'] } };
+				const base = SQONBuilder.in('name', ['Jim', 'Bob']);
+				const output = base.removeExactFilter(filter);
+
+				const expected = base;
+
+				expect(output).deep.contain(expected.toValue());
 			});
 		});
 	});

--- a/test/SQONBuilder.spec.ts
+++ b/test/SQONBuilder.spec.ts
@@ -940,6 +940,15 @@ describe('SQONBuilder', () => {
 
 				expect(output).deep.contain(expected.toValue());
 			});
+			it('makes no change if matching filter is in a nested opeartor', () => {
+				const filter: FilterOperator = { op: FilterKeys.In, content: { fieldName: 'name', value: ['Jim'] } };
+				const base = SQONBuilder.gt('age', 20).or(filter).lt('score', 50);
+				const output = base.removeExactFilter(filter);
+
+				const expected = base;
+
+				expect(output).deep.contain(expected.toValue());
+			});
 		});
 		describe('removeFilter', () => {
 			describe('all arguments', () => {
@@ -1047,7 +1056,6 @@ describe('SQONBuilder', () => {
 					expect(scalarOutput.toValue()).deep.equal(emptySQON().toValue());
 					expect(arrayOutput.toValue()).deep.equal(emptySQON().toValue());
 				});
-
 				it('match found in content - removes match', () => {
 					const input = SQONBuilder.in('name', ['Jim']).gt('age', 20).lt('score', 50);
 
@@ -1067,6 +1075,15 @@ describe('SQONBuilder', () => {
 					const expected = SQONBuilder.in('name', ['Jim']);
 
 					expect(output.toValue()).deep.equal(expected.toValue());
+				});
+				it('match in nested operator - no change', () => {
+					const filter: FilterOperator = { op: FilterKeys.In, content: { fieldName: 'name', value: ['Jim'] } };
+					const base = SQONBuilder.gt('age', 20).or(filter).lt('score', 50);
+					const output = base.removeFilter(filter.content.fieldName);
+
+					const expected = base;
+
+					expect(output).deep.contain(expected.toValue());
 				});
 			});
 		});

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -12,7 +12,7 @@ describe('index', () => {
 
 			// Test it builds
 			expect(SQONBuilder(`{"op":"in","content":{"fieldName":"name","value":["Jim"]}}`).toValue()).deep.equal({
-				op: Exports.ArrayFilterKeys.In,
+				op: Exports.FilterKeys.In,
 				content: {
 					fieldName: 'name',
 					value: ['Jim'],

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -19,6 +19,10 @@ describe('index', () => {
 				},
 			});
 		});
+		it('emptySQON is exported', () => {
+			const { default: SQONBuilder } = Exports;
+			expect(typeof SQONBuilder).equal('function');
+		});
 		it('reduceSQON is exported', () => {
 			const { reduceSQON } = Exports;
 			expect(typeof reduceSQON).equal('function');

--- a/test/types/sqon.spec.ts
+++ b/test/types/sqon.spec.ts
@@ -5,8 +5,11 @@ import {
 	FilterKeys,
 	FilterOperator,
 	isArrayFilter,
+	isArrayFilterKey,
 	isCombination,
 	isFilter,
+	isScalarFilter,
+	isScalarFilterKey,
 } from '../../src/types/sqon';
 
 const combo: CombinationOperator = { op: CombinationKeys.And, content: [] };
@@ -42,6 +45,35 @@ describe('types/sqon', () => {
 			});
 			it('rejects scalar filter', () => {
 				expect(isArrayFilter(scalarFilter)).false;
+			});
+		});
+		describe('isScalarFilter', () => {
+			it('validates scalar filter', () => {
+				expect(isScalarFilter(scalarFilter)).true;
+			});
+			it('rejects combination operator', () => {
+				expect(isScalarFilter(arrayFilter)).false;
+			});
+			it('rejects array filter', () => {
+				expect(isScalarFilter(combo)).false;
+			});
+		});
+		describe('isArrayFilterKey', () => {
+			it('validates array keys', () => {
+				expect(isArrayFilterKey(FilterKeys.In)).true;
+			});
+			it('rejects scalar keys', () => {
+				expect(isArrayFilterKey(FilterKeys.GreaterThan)).false;
+				expect(isArrayFilterKey(FilterKeys.LesserThan)).false;
+			});
+		});
+		describe('isScalarFilterKey', () => {
+			it('validates array keys', () => {
+				expect(isScalarFilterKey(FilterKeys.GreaterThan)).true;
+				expect(isScalarFilterKey(FilterKeys.LesserThan)).true;
+			});
+			it('rejects scalar keys', () => {
+				expect(isScalarFilterKey(FilterKeys.In)).false;
 			});
 		});
 	});

--- a/test/types/sqon.spec.ts
+++ b/test/types/sqon.spec.ts
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import {
+	CombinationKeys,
+	CombinationOperator,
+	FilterKeys,
+	FilterOperator,
+	isArrayFilter,
 	isCombination,
 	isFilter,
-	isArrayFilter,
-	CombinationOperator,
-	CombinationKeys,
-	FilterOperator,
-	FilterKeys,
 } from '../../src/types/sqon';
 
 const combo: CombinationOperator = { op: CombinationKeys.And, content: [] };

--- a/test/utils/checkMatchingFilter.spec.ts
+++ b/test/utils/checkMatchingFilter.spec.ts
@@ -1,8 +1,41 @@
 import { expect } from 'chai';
 import { ArrayFilter, FilterKeys, FilterOperator, ScalarFilter } from '../../src';
-import checkMatchingFilter from '../../src/utils/checkMatchingFilter';
+import checkMatchingFilter, { checkMatchingArrays } from '../../src/utils/checkMatchingFilter';
 
 describe('utils/checkMatchingFilter', () => {
+	describe('checkMatchingArrays', () => {
+		it('true when identical arrays', () => {
+			const a = [1, 2, 3, 4];
+			const b = [1, 2, 3, 4];
+			expect(checkMatchingArrays(a, b)).true;
+		});
+		it('true when empty arrays', () => {
+			const a: never[] = [];
+			const b: never[] = [];
+			expect(checkMatchingArrays(a, b)).true;
+		});
+		it('true when arrays with different orders', () => {
+			const a = [1, 2, 3, 4];
+			const b = [3, 2, 1, 4];
+			expect(checkMatchingArrays(a, b)).true;
+		});
+		it('true when when one array has duplicates', () => {
+			const a = [1, 2, 3, 4];
+			const b = [3, 2, 1, 4, 2, 3];
+			expect(checkMatchingArrays(a, b)).true;
+		});
+		it('false when arrays are different', () => {
+			const a = [1, 2];
+			const b = [3, 4];
+			expect(checkMatchingArrays(a, b)).false;
+		});
+		it('false when one array has more elements', () => {
+			const a = [1, 2, 3, 4];
+			const b = [1, 2, 3, 4, 5];
+			expect(checkMatchingArrays(a, b)).false;
+			expect(checkMatchingArrays(b, a)).false;
+		});
+	});
 	it('matches scalar filters', () => {
 		const a: ScalarFilter = { op: FilterKeys.GreaterThan, content: { fieldName: 'score', value: 90 } };
 		const match: ScalarFilter = { op: FilterKeys.GreaterThan, content: { fieldName: 'score', value: 90 } };

--- a/test/utils/checkMatchingFilter.spec.ts
+++ b/test/utils/checkMatchingFilter.spec.ts
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+import { ArrayFilter, FilterKeys, FilterOperator, ScalarFilter } from '../../src';
+import checkMatchingFilter from '../../src/utils/checkMatchingFilter';
+
+describe('utils/checkMatchingFilter', () => {
+	it('matches scalar filters', () => {
+		const a: ScalarFilter = { op: FilterKeys.GreaterThan, content: { fieldName: 'score', value: 90 } };
+		const match: ScalarFilter = { op: FilterKeys.GreaterThan, content: { fieldName: 'score', value: 90 } };
+		const notMatchValue: ScalarFilter = { op: FilterKeys.GreaterThan, content: { fieldName: 'score', value: 89 } };
+		const notMatchOp: ScalarFilter = { op: FilterKeys.LesserThan, content: { fieldName: 'score', value: 90 } };
+		const notMatchFieldName: ScalarFilter = { op: FilterKeys.GreaterThan, content: { fieldName: 'age', value: 90 } };
+		expect(checkMatchingFilter(a, match)).true;
+		expect(checkMatchingFilter(a, notMatchValue)).false;
+		expect(checkMatchingFilter(a, notMatchOp)).false;
+		expect(checkMatchingFilter(a, notMatchFieldName)).false;
+	});
+	it('matches array filters', () => {
+		const a: ArrayFilter = { op: FilterKeys.In, content: { fieldName: 'score', value: 90 } };
+		const match: ArrayFilter = { op: FilterKeys.In, content: { fieldName: 'score', value: 90 } };
+		const notMatchValue: ArrayFilter = { op: FilterKeys.In, content: { fieldName: 'score', value: 89 } };
+		const notMatchOp: FilterOperator = { op: FilterKeys.LesserThan, content: { fieldName: 'score', value: 90 } };
+		const notMatchFieldName: ArrayFilter = { op: FilterKeys.In, content: { fieldName: 'age', value: 90 } };
+		expect(checkMatchingFilter(a, match)).true;
+		expect(checkMatchingFilter(a, notMatchValue)).false;
+		expect(checkMatchingFilter(a, notMatchOp)).false;
+		expect(checkMatchingFilter(a, notMatchFieldName)).false;
+	});
+	it('matches array filters with mixed array orders', () => {
+		const a: ArrayFilter = { op: FilterKeys.In, content: { fieldName: 'name', value: ['Jim', 'Bob', 'May'] } };
+		const matchSameOrder: ArrayFilter = {
+			op: FilterKeys.In,
+			content: { fieldName: 'name', value: ['Jim', 'Bob', 'May'] },
+		};
+		const matchDifferentOrder: ArrayFilter = {
+			op: FilterKeys.In,
+			content: { fieldName: 'name', value: ['May', 'Jim', 'Bob'] },
+		};
+		const notMatchMissingValue: ArrayFilter = {
+			op: FilterKeys.In,
+			content: { fieldName: 'name', value: ['Jim', 'Bob'] },
+		};
+		const notMatchAddedValue: FilterOperator = {
+			op: FilterKeys.In,
+			content: { fieldName: 'name', value: ['Jim', 'Bob', 'May', 'Sue'] },
+		};
+		expect(checkMatchingFilter(a, matchSameOrder)).true;
+		expect(checkMatchingFilter(a, matchDifferentOrder)).true;
+		expect(checkMatchingFilter(a, notMatchMissingValue)).false;
+		expect(checkMatchingFilter(a, notMatchAddedValue)).false;
+	});
+});

--- a/test/utils/cloneDeepPojo.spec.ts
+++ b/test/utils/cloneDeepPojo.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import cloneDeepPojo from '../../src/utils/cloneDeepPojo';
 
-describe('cloneDeepPojo', () => {
+describe('utils/cloneDeepPojo', () => {
 	it('clones nested objects', () => {
 		const object = {
 			array: ['item', { a: 'objectInArray' }, 1234],

--- a/test/utils/cloneDeepValues.spec.ts
+++ b/test/utils/cloneDeepValues.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import cloneDeepPojo from '../../src/utils/cloneDeepPojo';
+import cloneDeepValues from '../../src/utils/cloneDeepValues';
 
 describe('utils/cloneDeepPojo', () => {
 	it('clones nested objects', () => {
@@ -10,7 +10,7 @@ describe('utils/cloneDeepPojo', () => {
 			object: { a: 'asdf', b: ['arrayInObject', 2345] },
 			nested1: { nested2: { nested3: {} } },
 		};
-		const clone = cloneDeepPojo(object);
+		const clone = cloneDeepValues(object);
 		expect(clone).not.equal(object);
 		expect(clone).deep.equal(object);
 		expect(clone).deep.contain(object);
@@ -28,7 +28,7 @@ describe('utils/cloneDeepPojo', () => {
 		};
 		const expected = { a: 'string' };
 
-		const clone = cloneDeepPojo(object);
+		const clone = cloneDeepValues(object);
 		expect(clone).deep.equal(expected);
 		expect(clone).not.haveOwnProperty('function');
 	});

--- a/test/utils/filterDuplicates.spec.ts
+++ b/test/utils/filterDuplicates.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import filterDuplicates from '../../src/utils/filterDuplicates';
 
-describe('filterDuplicates', () => {
+describe('utils/filterDuplicates', () => {
 	it('no duplicates - not modified', () => {
 		const input = [1, 2, 3, 4];
 		const output = input.filter(filterDuplicates);

--- a/test/utils/reduceSQON.spec.ts
+++ b/test/utils/reduceSQON.spec.ts
@@ -11,7 +11,7 @@ import {
 	reduceSQON,
 } from '../../src';
 
-describe('reduceSQON', () => {
+describe('utils/reduceSQON', () => {
 	describe('filters', () => {
 		// Filters of the same type and same name in the same combination operator can combine into a single filter
 		it('combines multiple `in` filters', () => {


### PR DESCRIPTION
For https://github.com/overture-stack/sqon-builder/issues/3

Adds 3 functions to the SQONBuilder:
`removeExactFilter(filter)` - remove a filter that exactly matches the argument
`removeFilter(name, op, value)` - remove a filter that matches the provided arguments (op and value are optional)
`setFilter(name, op, value)` - create or update filter matching name and op

Some small refactoring was done along the way:
* `createFilter` - convenience utility to create an object that matches the structure of a filter, with argument types that ensure the values match the operator's value requirments
* `checkMatchingFilter` - utility that runs the logic to check if two filters match, ignoring the order of arrays and any duplicate values
* `emptySQON` - returns a SQON now and now a SQONBuilder. It is exported in the package.
* custom type guards convenience functions for both filter categories and for checking their keys
* a bunch of documentation updates