### PR TITLE
Add `pivot` to CombinationOperator model and functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,23 +241,23 @@ Lesser Than operator. Create a filter requiring the given field to be lesser tha
 Example: `SQONBuilder.lt('count', 100)`
 
 #### Combine: And
-`SQONBuilder.and(sqon: SQON | SQON[]) => SQONBuilder`
+`SQONBuilder.and(sqon: SQON | SQON[], pivot?: string) => SQONBuilder`
 
-All filters in the resulting SQON must be true.
+Wrap the provided SQONs in an `and` operator, creating a filter requiring all the nested filters to be true.
 
 Example: `SQONBuilder.and( [someSqon, anotherSqon] )`
 
 #### Combine: Or
-`SQONBuilder.or(sqon: SQON | SQON[]) => SQONBuilder`
+`SQONBuilder.or(sqon: SQON | SQON[], pivot?: string) => SQONBuilder`
 
-At least one filter in the resulting SQON must be true.
+Wrap the provided SQONs in an `and` operator, creating a filter requiring at least one of the nested filters to be true.
 
 Example: `SQONBuilder.or( [someSqon, anotherSqon] )`
 
 #### Combine: Not
-`SQONBuilder.not(sqon: SQON | SQON[]) => SQONBuilder`
+`SQONBuilder.not(sqon: SQON | SQON[], pivot?: string) => SQONBuilder`
 
-None of the filters in the resulting SQON can be true.
+Wrap the provided SQONs in a `not` operator, creating a filter requiring all the nested filters to be false.
 
 Example: `SQONBuilder.not( [someSqon] )`
 

--- a/src/SQONBuilder.ts
+++ b/src/SQONBuilder.ts
@@ -261,7 +261,7 @@ const createBuilder = (sqon: SQON): SQONBuilder => {
 	};
 };
 
-const combine = (op: CombinationKey, sqon: SQON, content: SQON | SQON[]): CombinationOperator => {
+const combine = (op: CombinationKey, sqon: SQON, content: SQON | SQON[], pivot?: string): CombinationOperator => {
 	if (sqon.op === op) {
 		return {
 			op,
@@ -291,20 +291,20 @@ const _from = (input: unknown): SQONBuilder => {
 };
 const _and =
 	(original: SQON) =>
-	(content: SQON | SQON[]): SQONBuilder =>
-		createBuilder(combine(CombinationKeys.And, original, content));
+	(content: SQON | SQON[], pivot?: string): SQONBuilder =>
+		createBuilder(combine(CombinationKeys.And, original, content, pivot));
 const _or =
 	(original: SQON) =>
-	(content: SQON | SQON[]): SQONBuilder =>
-		createBuilder(combine(CombinationKeys.Or, original, content));
+	(content: SQON | SQON[], pivot?: string): SQONBuilder =>
+		createBuilder(combine(CombinationKeys.Or, original, content, pivot));
 const _not =
 	(original: SQON) =>
-	(content: SQON | SQON[]): SQONBuilder => {
+	(content: SQON | SQON[], pivot?: string): SQONBuilder => {
 		const notOp: CombinationOperator = {
 			op: CombinationKeys.Not,
 			content: asArray(content),
 		};
-		return createBuilder(combine(CombinationKeys.And, original, notOp));
+		return createBuilder(combine(CombinationKeys.And, original, notOp, pivot));
 	};
 const _in =
 	(original: SQON) =>

--- a/src/SQONBuilder.ts
+++ b/src/SQONBuilder.ts
@@ -307,8 +307,9 @@ const _not =
 		const notOp: CombinationOperator = {
 			op: CombinationKeys.Not,
 			content: asArray(content),
+			pivot,
 		};
-		return createBuilder(combine(CombinationKeys.And, original, notOp, pivot));
+		return createBuilder(combine(CombinationKeys.And, original, notOp));
 	};
 const _in =
 	(original: SQON) =>

--- a/src/SQONBuilder.ts
+++ b/src/SQONBuilder.ts
@@ -26,9 +26,9 @@ import { createFilter } from './utils/createFilter';
 import reduceSQON from './utils/reduceSQON';
 
 type SQONBuilder = {
-	and: (content: SQON | SQON[]) => SQONBuilder;
-	or: (content: SQON | SQON[]) => SQONBuilder;
-	not: (content: SQON | SQON[]) => SQONBuilder;
+	and: (content: SQON | SQON[], pivot?: string) => SQONBuilder;
+	or: (content: SQON | SQON[], pivot?: string) => SQONBuilder;
+	not: (content: SQON | SQON[], pivot?: string) => SQONBuilder;
 
 	in: (fieldName: string, value: ArrayFilterValue) => SQONBuilder;
 	gt: (fieldName: string, value: ScalarFilterValue) => SQONBuilder;
@@ -147,7 +147,7 @@ const createBuilder = (sqon: SQON): SQONBuilder => {
 			const filteredContent = _sqon.content.filter(
 				(operator) => !isFilter(operator) || !checkMatchingFilter(operator, filter),
 			);
-			const updated: CombinationOperator = { op: _sqon.op, content: filteredContent };
+			const updated: CombinationOperator = { op: _sqon.op, content: filteredContent, pivot: _sqon.pivot };
 			return createBuilder(updated);
 		}
 	};
@@ -199,7 +199,7 @@ const createBuilder = (sqon: SQON): SQONBuilder => {
 		const filteredContent = _sqon.content.filter((operator) => isCombination(operator) || !isMatchArgs(operator));
 
 		if (valuesToFilter === undefined) {
-			const updated: CombinationOperator = { op: _sqon.op, content: filteredContent };
+			const updated: CombinationOperator = { op: _sqon.op, content: filteredContent, pivot: _sqon.pivot };
 			return createBuilder(updated);
 		}
 
@@ -211,7 +211,7 @@ const createBuilder = (sqon: SQON): SQONBuilder => {
 				? filterValuesFromFilter(operator, valuesToFilter)
 				: operator,
 		);
-		const updated: CombinationOperator = { op: _sqon.op, content: outputContent };
+		const updated: CombinationOperator = { op: _sqon.op, content: outputContent, pivot: _sqon.pivot };
 		return createBuilder(updated);
 	};
 
@@ -262,17 +262,21 @@ const createBuilder = (sqon: SQON): SQONBuilder => {
 };
 
 const combine = (op: CombinationKey, sqon: SQON, content: SQON | SQON[], pivot?: string): CombinationOperator => {
-	if (sqon.op === op) {
-		return {
-			op,
-			content: [...sqon.content, ...asArray(content)],
-		};
+	const output: CombinationOperator = { op, content: [] };
+	if (sqon.op === op && sqon.pivot === pivot) {
+		// provided sqon has same operation as requested:
+		//   don't add wrapper, insert new content into existing sqon
+		output.content = output.content.concat(sqon.content, content);
 	} else {
-		return {
-			op,
-			content: [sqon, ...asArray(content)],
-		};
+		output.content = output.content.concat(sqon, content);
 	}
+
+	if (pivot !== undefined) {
+		// dont automatically assign pivot: undefined to an operator, it will then appear in every output and that is not desired
+		// optionally assigning pivot only if it has a value avoids this
+		output.pivot = pivot;
+	}
+	return output;
 };
 
 /**

--- a/src/types/sqon.ts
+++ b/src/types/sqon.ts
@@ -112,10 +112,12 @@ export const FilterOperator = zod.discriminatedUnion('op', [InFilter, GreaterTha
 export type CombinationOperator = {
 	op: CombinationKey;
 	content: (CombinationOperator | FilterOperator)[];
+	pivot?: string;
 };
 export const CombinationOperator: zod.ZodType<CombinationOperator> = zod.object({
 	op: zod.union([zod.literal(CombinationKeys.And), zod.literal(CombinationKeys.Not), zod.literal(CombinationKeys.Or)]),
 	content: zod.array(zod.union([FilterOperator, zod.lazy(() => CombinationOperator)])),
+	pivot: zod.string().optional(),
 });
 
 export const Operator = zod.union([CombinationOperator, FilterOperator]);

--- a/src/utils/reduceSQON.ts
+++ b/src/utils/reduceSQON.ts
@@ -33,6 +33,7 @@ const reduceSQON = (sqon: SQON): SQON => {
 		const output: CombinationOperator = {
 			op: sqon.op,
 			content: [],
+			pivot: sqon.pivot,
 		};
 		for (const innerSqon of sqon.content) {
 			// Filters are added to output content
@@ -101,7 +102,7 @@ const reduceSQON = (sqon: SQON): SQON => {
 					output.content.push(innerSqon);
 					continue;
 				}
-				if (innerSqon.op === output.op) {
+				if (innerSqon.op === output.op && innerSqon.pivot === output.pivot) {
 					// 4. inner sqon op matches outter sqon, remove inner combination and use the content
 					output.content.push(...innerSqon.content);
 					continue;

--- a/src/utils/reduceSQON.ts
+++ b/src/utils/reduceSQON.ts
@@ -33,8 +33,12 @@ const reduceSQON = (sqon: SQON): SQON => {
 		const output: CombinationOperator = {
 			op: sqon.op,
 			content: [],
-			pivot: sqon.pivot,
 		};
+		if (sqon.pivot !== undefined) {
+			// dont automatically assign `pivot: undefined` to an operator, it will then appear in every output and that is not desired
+			// optionally assigning pivot only if it has a value avoids this
+			output.pivot = sqon.pivot;
+		}
 		for (const innerSqon of sqon.content) {
 			// Filters are added to output content
 			if (isFilter(innerSqon)) {

--- a/test/SQONBuilder.spec.ts
+++ b/test/SQONBuilder.spec.ts
@@ -1036,6 +1036,47 @@ describe('SQONBuilder', () => {
 					.not(SQONBuilder.gt('age', 25));
 				expect(output).deep.contain(expectedSqon);
 			});
+			it('does not combine nested or with different pivots', () => {
+				// This test puts the pivot in a different layer than the similar test in builder functions.and
+				// So its useful to have them both.
+				const expectedSqon: SQON = {
+					op: CombinationKeys.And,
+					content: [
+						{
+							op: FilterKeys.In,
+							content: {
+								fieldName: 'name',
+								value: ['Jim', 'Bob'],
+							},
+						},
+						{
+							op: CombinationKeys.Not,
+							content: [
+								{
+									op: FilterKeys.GreaterThan,
+									content: {
+										fieldName: 'user.age',
+										value: 30,
+									},
+								},
+								{
+									op: FilterKeys.LesserThan,
+									content: {
+										fieldName: 'user.score',
+										value: 50,
+									},
+								},
+							],
+							pivot: 'user',
+						},
+					],
+				};
+				const output = SQONBuilder.in('name', ['Jim', 'Bob']).not(
+					[SQONBuilder.gt('user.age', 30), SQONBuilder.lt('user.score', 50)],
+					'user',
+				);
+				expect(output).deep.contain(expectedSqon);
+			});
 		});
 		describe('removeExactFilter', () => {
 			it('removes matching filter', () => {

--- a/test/utils/reduceSQON.spec.ts
+++ b/test/utils/reduceSQON.spec.ts
@@ -179,5 +179,51 @@ describe('utils/reduceSQON', () => {
 			const expected = { op: CombinationKeys.And, content: [] };
 			expect(reduceSQON(input)).deep.equal(expected);
 		});
+		it('does not output undefined pivot', () => {
+			const input = {
+				op: CombinationKeys.And,
+				content: [
+					{ op: CombinationKeys.And, content: [] },
+					{ op: CombinationKeys.Or, content: [] },
+					{ op: CombinationKeys.Not, content: [] },
+				],
+			};
+			expect(reduceSQON(input)).not.haveOwnProperty('pivot');
+		});
+		it('outputs a defined pivot', () => {
+			const input = {
+				op: CombinationKeys.And,
+				content: [
+					{ op: CombinationKeys.And, content: [] },
+					{ op: CombinationKeys.Or, content: [] },
+					{ op: CombinationKeys.Not, content: [] },
+				],
+				pivot: 'user',
+			};
+			expect(reduceSQON(input)).haveOwnProperty('pivot');
+			expect(reduceSQON(input)).deep.contain({ pivot: 'user' });
+		});
+		it('does not combine operators with different pivots', () => {
+			const filterA: FilterOperator = { op: FilterKeys.In, content: { fieldName: 'name', value: ['Jim', 'Sue'] } };
+			const filterB: FilterOperator = { op: FilterKeys.GreaterThan, content: { fieldName: 'num', value: 2 } };
+			const filterC: FilterOperator = { op: FilterKeys.LesserThan, content: { fieldName: 'score', value: 10 } };
+			const comboA: CombinationOperator = { op: CombinationKeys.And, content: [filterA, filterB], pivot: 'pilot' };
+			const comboB: CombinationOperator = { op: CombinationKeys.And, content: [filterC], pivot: 'actor' };
+			const input: CombinationOperator = { op: CombinationKeys.And, content: [comboA, comboB], pivot: 'doctor' };
+
+			// Remove AND around single filter, keep the other AND with different pivot
+			const expected = { op: CombinationKeys.And, content: [comboA, filterC], pivot: 'doctor' };
+			expect(reduceSQON(input)).deep.equal(expected);
+		});
+		it('combines operators with same pivots', () => {
+			const filterA: FilterOperator = { op: FilterKeys.In, content: { fieldName: 'name', value: ['Jim', 'Sue'] } };
+			const filterB: FilterOperator = { op: FilterKeys.GreaterThan, content: { fieldName: 'num', value: 2 } };
+			const filterC: FilterOperator = { op: FilterKeys.LesserThan, content: { fieldName: 'score', value: 10 } };
+			const comboA: CombinationOperator = { op: CombinationKeys.And, content: [filterA, filterB], pivot: 'user' };
+			const comboB: CombinationOperator = { op: CombinationKeys.And, content: [filterC], pivot: 'user' };
+			const input: CombinationOperator = { op: CombinationKeys.And, content: [comboA, comboB], pivot: 'user' };
+			const expected = { op: CombinationKeys.And, content: [filterA, filterB, filterC], pivot: 'user' };
+			expect(reduceSQON(input)).deep.equal(expected);
+		});
 	});
 });


### PR DESCRIPTION
Issue: https://github.com/overture-stack/sqon-builder/issues/4

Allows `pivot` property to be added to Combinations through the SQONBuilder. Also correctly validates SQONs that have this property.

`reduceSQON` functionality had to be slightly amended to ensure that we don't combine operators with different pivot values.

Built on top of [modify filters PR](https://github.com/overture-stack/sqon-builder/pull/11), will mark ready for review once merged.